### PR TITLE
Paginate

### DIFF
--- a/controllers/incidents.js
+++ b/controllers/incidents.js
@@ -13,10 +13,15 @@ var allIncidents = function(req, res) {
   if (searchQuery["invalid_parameter"]) {
     return res.json({invalid_request: "unrecognized search parameter"})
   } else {
-    models.Incident.findAndCountAll({where: searchQuery, offset: offset, limit: 100, include: [ models.Beat, models.Disposition, models.CallType ]}).then(function(results) {
-      customizeJsonKeys(results);
-      serializeIncidents(results);
-      return res.json(results);
+    models.Incident.findAndCountAll({where: searchQuery,
+                                     offset: offset,
+                                     limit: 100,
+                                     order: '"date" ASC',
+                                     include: [ models.Beat, models.Disposition, models.CallType ]})
+                    .then(function(results) {
+                                    customizeJsonKeys(results);
+                                    serializeIncidents(results);
+                                    return res.json(results);
     });
   };
 }
@@ -42,17 +47,22 @@ var transformQuery = function(query) {
   for(var searchItem in query) {
     if(queryHashMap[searchItem] === "page") {
       continue;
-    } else if(!queryHashMap[searchItem]) {
+    }
+    else if(!queryHashMap[searchItem]) {
       newQuery["invalid_parameter"] = query[searchItem];
-    } else if (searchItem === "date") {
+    }
+    else if (searchItem === "date") {
       var start = query[searchItem] + "T00:00:00.000Z"
       var end = query[searchItem] + "T23:59:59.000Z"
       newQuery[queryHashMap[searchItem]] = { between: [start, end]}
-    } else if (searchItem === "start_date"){
+    }
+    else if (searchItem === "start_date"){
       newQuery[queryHashMap[searchItem]] = { gte: new Date(query[searchItem])}
-    } else if (searchItem === "end_date"){
+    }
+    else if (searchItem === "end_date"){
       newQuery[queryHashMap[searchItem]] = { lt: new Date(query[searchItem])}
-    } else {
+    }
+    else {
       newQuery[queryHashMap[searchItem]] = query[searchItem];
     };
   };

--- a/controllers/incidents.js
+++ b/controllers/incidents.js
@@ -1,4 +1,6 @@
 var models  = require('../models');
+var IncidentsSerializer = require('../serializers/incidents-serializer')
+var incidentsSerializer = new IncidentsSerializer();
 const querystring = require('querystring');
 
 exports.getIncidents = function(req, res) {
@@ -6,74 +8,14 @@ exports.getIncidents = function(req, res) {
 };
 
 var allIncidents = function(req, res) {
-    var searchQuery = transformQuery(req.query);
-    if (searchQuery["invalid_parameter"]) {
-      return res.json({invalid_request: "unrecognized search parameter"})
-    };
-    models.Incident.findByQuery(models, searchQuery)
-                   .then(function(results) {
-                        customizeJsonKeys(results);
-                        serializeIncidents(results);
-                        return res.json(results);
-    });
-};
-
-var paramsToModelFields =
-                   {number:         "number",
-                    priority:       "priority",
-                    beat:           "Beat.number",
-                    neighborhood:   "Beat.neighborhood",
-                    disp_code:      "Disposition.code",
-                    disp_desc:      "Disposition.description",
-                    call_code:      "CallType.code",
-                    call_desc:      "CallType.description",
-                    street:         "street",
-                    street_number:  "street_number",
-                    street_dir:     "street_dir",
-                    date:           "date",
-                    start_date:     "date",
-                    end_date:       "date",
-                    page:           "page"};
-
-var transformQuery = function(query) {
-  var newQuery = {}
-  for(var searchItem in query) {
-    if(paramsToModelFields[searchItem] === "page") {
-      continue;
-    }
-    else if(!paramsToModelFields[searchItem]) {
-      newQuery["invalid_parameter"] = query[searchItem];
-    }
-    else if (searchItem === "date") {
-      var start = query[searchItem] + "T00:00:00.000Z"
-      var end = query[searchItem] + "T23:59:59.000Z"
-      newQuery[paramsToModelFields[searchItem]] = { between: [start, end]}
-    }
-    else if (searchItem === "start_date"){
-      newQuery[paramsToModelFields[searchItem]] = { gte: new Date(query[searchItem])}
-    }
-    else if (searchItem === "end_date"){
-      newQuery[paramsToModelFields[searchItem]] = { lt: new Date(query[searchItem])}
-    }
-    else {
-      newQuery[paramsToModelFields[searchItem]] = query[searchItem];
-    };
+  var searchQuery = incidentsSerializer.transformQuery(req.query);
+  if (searchQuery["invalid_parameter"]) {
+    return res.json({invalid_request: "unrecognized search parameter"})
   };
-  return newQuery;
+  models.Incident.findByQuery(models, searchQuery)
+  .then(function(results) {
+    incidentsSerializer.customizeJsonKeys(results);
+    incidentsSerializer.serializeIncidents(results);
+    return res.json(results);
+  });
 };
-
-var customizeJsonKeys = function(results) {
-  var count = results[0];
-  var incidents = results[1];
-  results.total_incidents = results.count;
-  results.incidents = results.rows;
-  delete results.count;
-  delete results.rows;
-  return results;
-}
-
-var serializeIncidents = function(results) {
-  for(i in results["incidents"]) {
-    results["incidents"][i] = results["incidents"][i].serialize();
-  }
-}

--- a/controllers/incidents.js
+++ b/controllers/incidents.js
@@ -5,54 +5,52 @@ exports.getIncidents = function(req, res) {
   allIncidents(req, res)
 };
 
-
 var allIncidents = function(req, res) {
   var page = req.query["page"] || 1;
   var offset = 100 * (page - 1);
-  var searchQuery = mapQuery(req.query);
+  var searchQuery = transformQuery(req.query);
 
   if (searchQuery["invalid_parameter"]) {
     return res.json({invalid_request: "unrecognized search parameter"})
   } else {
-    models.Incident.findAll({where: searchQuery, offset: offset, limit: 100, include: [ models.Beat, models.Disposition, models.CallType ]}).then(function(incidents) {
-      for(i in incidents) {
-        incidents[i] = incidents[i].serialize();
-      }
-      return res.json(incidents);
+    models.Incident.findAndCountAll({where: searchQuery, offset: offset, limit: 100, include: [ models.Beat, models.Disposition, models.CallType ]}).then(function(results) {
+      customizeJsonKeys(results);
+      serializeIncidents(results);
+      return res.json(results);
     });
   };
 }
 
-var queryHashMap = {number: "number",
-                    priority: "priority",
-                    beat: "Beat.number",
-                    neighborhood: "Beat.neighborhood",
-                    disp_code: "Disposition.code",
-                    disp_desc: "Disposition.description",
-                    call_code: "CallType.code",
-                    call_desc: "CallType.description",
-                    street: "street",
-                    street_number: "street_number",
-                    street_dir: "street_dir",
-                    date: "date",
-                    start_date: "date",
-                    end_date: "date",
-                    page: "page"};
+var queryHashMap = {number:         "number",
+                    priority:       "priority",
+                    beat:           "Beat.number",
+                    neighborhood:   "Beat.neighborhood",
+                    disp_code:      "Disposition.code",
+                    disp_desc:      "Disposition.description",
+                    call_code:      "CallType.code",
+                    call_desc:      "CallType.description",
+                    street:         "street",
+                    street_number:  "street_number",
+                    street_dir:     "street_dir",
+                    date:           "date",
+                    start_date:     "date",
+                    end_date:       "date",
+                    page:           "page"};
 
-var mapQuery = function(query) {
+var transformQuery = function(query) {
   var newQuery = {}
   for(var searchItem in query) {
     if(queryHashMap[searchItem] === "page") {
       continue;
     } else if(!queryHashMap[searchItem]) {
       newQuery["invalid_parameter"] = query[searchItem];
-    } else if (searchItem == "date") {
+    } else if (searchItem === "date") {
       var start = query[searchItem] + "T00:00:00.000Z"
       var end = query[searchItem] + "T23:59:59.000Z"
       newQuery[queryHashMap[searchItem]] = { between: [start, end]}
-    } else if (searchItem == "start_date"){
+    } else if (searchItem === "start_date"){
       newQuery[queryHashMap[searchItem]] = { gte: new Date(query[searchItem])}
-    } else if (searchItem == "end_date"){
+    } else if (searchItem === "end_date"){
       newQuery[queryHashMap[searchItem]] = { lt: new Date(query[searchItem])}
     } else {
       newQuery[queryHashMap[searchItem]] = query[searchItem];
@@ -60,3 +58,19 @@ var mapQuery = function(query) {
   };
   return newQuery;
 };
+
+var customizeJsonKeys = function(results) {
+  var count = results[0];
+  var incidents = results[1];
+  results.total_incidents = results.count;
+  results.incidents = results.rows;
+  delete results.count;
+  delete results.rows;
+  return results;
+}
+
+var serializeIncidents = function(results) {
+  for(i in results["incidents"]) {
+    results["incidents"][i] = results["incidents"][i].serialize();
+  }
+}

--- a/controllers/incidents.js
+++ b/controllers/incidents.js
@@ -7,11 +7,14 @@ exports.getIncidents = function(req, res) {
 
 
 var allIncidents = function(req, res) {
+  var page = req.query["page"] || 1;
+  var offset = 100 * (page - 1);
   var searchQuery = mapQuery(req.query);
+
   if (searchQuery["invalid_parameter"]) {
     return res.json({invalid_request: "unrecognized search parameter"})
   } else {
-    models.Incident.findAll({where: searchQuery, limit: 100, include: [ models.Beat, models.Disposition, models.CallType ]}).then(function(incidents) {
+    models.Incident.findAll({where: searchQuery, offset: offset, limit: 100, include: [ models.Beat, models.Disposition, models.CallType ]}).then(function(incidents) {
       for(i in incidents) {
         incidents[i] = incidents[i].serialize();
       }
@@ -33,12 +36,15 @@ var queryHashMap = {number: "number",
                     street_dir: "street_dir",
                     date: "date",
                     start_date: "date",
-                    end_date: "date"};
+                    end_date: "date",
+                    page: "page"};
 
 var mapQuery = function(query) {
   var newQuery = {}
   for(var searchItem in query) {
-    if(!queryHashMap[searchItem]) {
+    if(queryHashMap[searchItem] === "page") {
+      continue;
+    } else if(!queryHashMap[searchItem]) {
       newQuery["invalid_parameter"] = query[searchItem];
     } else if (searchItem == "date") {
       var start = query[searchItem] + "T00:00:00.000Z"

--- a/controllers/incidents.js
+++ b/controllers/incidents.js
@@ -12,10 +12,9 @@ var allIncidents = function(req, res) {
   if (searchQuery["invalid_parameter"]) {
     return res.json({invalid_request: "unrecognized search parameter"})
   };
-  models.Incident.findByQuery(models, searchQuery)
+  models.Incident.findByQuery(models, searchQuery, req.query["page"])
   .then(function(results) {
-    incidentsSerializer.customizeJsonKeys(results);
-    incidentsSerializer.serializeIncidents(results);
+    incidentsSerializer.serialize(results);
     return res.json(results);
   });
 };

--- a/models/incident.js
+++ b/models/incident.js
@@ -61,8 +61,8 @@ module.exports = function(sequelize, DataTypes) {
           }
         });
       },
-      findByQuery: function(models, query) {
-        var page = query["page"] || 1;
+      findByQuery: function(models, query, page) {
+        var page = page || 1;
         var offset = 100 * (page - 1);
         return Incident.findAndCountAll({
                         where: query,

--- a/models/incident.js
+++ b/models/incident.js
@@ -60,6 +60,17 @@ module.exports = function(sequelize, DataTypes) {
             allowNull: false
           }
         });
+      },
+      findByQuery: function(models, query) {
+        var page = query["page"] || 1;
+        var offset = 100 * (page - 1);
+        return Incident.findAndCountAll({
+                        where: query,
+                        offset: offset,
+                        limit: 100,
+                        order: '"date" ASC',
+                        include: [ {model: models.Beat}, {model: models.Disposition},{model: models.CallType}]
+        });
       }
     },
     underscored: true,

--- a/public/dist/api-doc.json
+++ b/public/dist/api-doc.json
@@ -16,13 +16,13 @@
       "/incidents": {
         "get": {
           "tags": ["All Incidents"],
-          "summary": "Get police inidents.  Optional search available for multiple fields",
+          "summary": "Get police inidents.  Optional search available for multiple fields.  Returns 100 results at a time.  Use page parameter to get later results.",
           "description": "Get incidents by searching various fields, including: incident number, priority, beat, neighbrhood, street, street number, date, start date, end date, disposition code, disposition description, call type, and/or call type description.",
           "parameters":[
             {
                "name":"page",
                "in":"query",
-               "description":"The page number of the incidents you want to fetch.  Response is limited to 100 incidents.  The number of incidents matching the search parameters is provided in the response.  To get each subsequent set of results, use a page parameter to cycle through the results",
+               "description":"The page number of the incidents you want to fetch.  Each page provides 100 results. The number of incidents matching the search parameters is provided in the response.  To get each subsequent set of results, use a page parameter to cycle through the results",
                "required":false,
                "type":"string"
             },

--- a/public/dist/api-doc.json
+++ b/public/dist/api-doc.json
@@ -19,6 +19,13 @@
           "summary": "Get police inidents.  Optional search available for multiple fields",
           "description": "Get incidents by searching various fields, including: incident number, priority, beat, neighbrhood, street, street number, date, start date, end date, disposition code, disposition description, call type, and/or call type description.",
           "parameters":[
+            {
+               "name":"page",
+               "in":"query",
+               "description":"The page number of the incidents you want to fetch.  Response is limited to 100 incidents.  The number of incidents matching the search parameters is provided in the response.  To get each subsequent set of results, use a page parameter to cycle through the results",
+               "required":false,
+               "type":"string"
+            },
            {
               "name":"number",
               "in":"query",
@@ -117,35 +124,43 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "incident number": {
+                  "total_incidents": {
                     "type": "string"
                   },
-                  "date": {
-                    "type": "string"
-                  },
-                  "address": {
-                    "type": "string"
-                  },
-                  "priority": {
-                    "type": "string"
-                  },
-                  "beat": {
-                    "type": "string"
-                  },
-                  "neighborhood": {
-                    "type": "string"
-                  },
-                  "disposition code": {
-                    "type": "string"
-                  },
-                  "disposition description": {
-                    "type": "string"
-                  },
-                  "call type code": {
-                    "type": "string"
-                  },
-                  "call type description": {
-                    "type": "string"
+                  "incidents": {
+                    "type": "object",
+                    "properties": {
+                      "incident number": {
+                        "type": "string"
+                      },
+                      "date": {
+                        "type": "string"
+                      },
+                      "address": {
+                        "type": "string"
+                      },
+                      "priority": {
+                        "type": "string"
+                      },
+                      "beat": {
+                        "type": "string"
+                      },
+                      "neighborhood": {
+                        "type": "string"
+                      },
+                      "disposition code": {
+                        "type": "string"
+                      },
+                      "disposition description": {
+                        "type": "string"
+                      },
+                      "call type code": {
+                        "type": "string"
+                      },
+                      "call type description": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }

--- a/serializers/incidents-serializer.js
+++ b/serializers/incidents-serializer.js
@@ -53,7 +53,8 @@ IncidentsSerializer.prototype.customizeJsonKeys = function(results) {
   return results;
 }
 
-IncidentsSerializer.prototype.serializeIncidents = function(results) {
+IncidentsSerializer.prototype.serialize = function(results) {
+  this.customizeJsonKeys(results);
   for(i in results["incidents"]) {
     results["incidents"][i] = results["incidents"][i].serialize();
   }

--- a/serializers/incidents-serializer.js
+++ b/serializers/incidents-serializer.js
@@ -1,0 +1,62 @@
+var incidents  = require('../models/incident');
+
+function IncidentsSerializer() {
+    this.paramsToFields = {number:         "number",
+                           priority:       "priority",
+                           beat:           "Beat.number",
+                           neighborhood:   "Beat.neighborhood",
+                           disp_code:      "Disposition.code",
+                           disp_desc:      "Disposition.description",
+                           call_code:      "CallType.code",
+                           call_desc:      "CallType.description",
+                           street:         "street",
+                           street_number:  "street_number",
+                           street_dir:     "street_dir",
+                           date:           "date",
+                           start_date:     "date",
+                           end_date:       "date",
+                           page:           "page"}
+                        }
+
+IncidentsSerializer.prototype.transformQuery = function(query) {
+  var newQuery = {}
+  for(var searchItem in query) {
+    if(this.paramsToFields[searchItem] === "page") {
+      continue;
+    }
+    else if(!this.paramsToFields[searchItem]) {
+      newQuery["invalid_parameter"] = query[searchItem];
+    }
+    else if (searchItem === "date") {
+      var start = query[searchItem] + "T00:00:00.000Z"
+      var end = query[searchItem] + "T23:59:59.000Z"
+      newQuery[this.paramsToFields[searchItem]] = { between: [start, end]}
+    }
+    else if (searchItem === "start_date"){
+      newQuery[this.paramsToFields[searchItem]] = { gte: new Date(query[searchItem])}
+    }
+    else if (searchItem === "end_date"){
+      newQuery[this.paramsToFields[searchItem]] = { lt: new Date(query[searchItem])}
+    }
+    else {
+      newQuery[this.paramsToFields[searchItem]] = query[searchItem];
+    };
+  };
+  return newQuery;
+}
+
+IncidentsSerializer.prototype.customizeJsonKeys = function(results) {
+  results.total_incidents = results.count;
+  results.incidents = results.rows;
+  delete results.count;
+  delete results.rows;
+  return results;
+}
+
+IncidentsSerializer.prototype.serializeIncidents = function(results) {
+  for(i in results["incidents"]) {
+    results["incidents"][i] = results["incidents"][i].serialize();
+  }
+}
+
+module.exports = IncidentsSerializer;

--- a/test/incident-api-test.js
+++ b/test/incident-api-test.js
@@ -25,11 +25,21 @@ describe('Incident API', () => {
   });
 
   describe('GET /api/v1/incidents', () => {
+
+    it('should return count of total incidents', (done) => {
+      this.request.get('/api/v1/incidents', (error, response) => {
+        if (error) { done(error); }
+        var parsed = JSON.parse(response.body)
+        assert.isNotNaN(parseInt(parsed.total_incidents));
+        done();
+      });
+    });
+
     it('should return an array of incidents', (done) => {
       this.request.get('/api/v1/incidents', (error, response) => {
         if (error) { done(error); }
         var parsed = JSON.parse(response.body)
-        assert.isArray(parsed);
+        assert.isArray(parsed.incidents);
         done();
       });
     });
@@ -39,7 +49,7 @@ describe('Incident API', () => {
       this.request.get('/api/v1/incidents', (error, response) => {
         if (error) { done(error); }
         var parsed = JSON.parse(response.body)
-        assert.equal(parsed.length, numIncidentsPerPage);
+        assert.equal(parsed.incidents.length, numIncidentsPerPage);
         done();
       });
     });
@@ -47,9 +57,9 @@ describe('Incident API', () => {
     it('should return incidents with correct keys', (done) => {
       this.request.get('/api/v1/incidents', (error, response) => {
         if (error) { done(error); }
-        var parsedIncident = JSON.parse(response.body)[0];
-        var keys = Object.keys(parsedIncident);
-        assert.isObject(parsedIncident);
+        var parsedJson = JSON.parse(response.body);
+        var keys = Object.keys(parsedJson.incidents[0]);
+        assert.isObject(parsedJson);
         assert.equal(keys.length, 10);
         assert.equal(keys.indexOf("incident number"), 0);
         assert.equal(keys.indexOf("date"), 1);
@@ -62,6 +72,33 @@ describe('Incident API', () => {
         assert.equal(keys.indexOf("call type code"), 8);
         assert.equal(keys.indexOf("call type description"), 9);
         done();
+      });
+    });
+
+    it('should paginate results', (done) => {
+      var page = 2;
+      var numIncidentsPerPage = 100;
+      this.request.get('/api/v1/incidents?page=' + page, (error, response) => {
+        if (error) { done(error); }
+        var parsedJson = JSON.parse(response.body);
+        assert.equal(parsedJson.incidents.length, numIncidentsPerPage);
+        done();
+      });
+    });
+
+    xit('should paginate results and return different incidents', (done) => {
+      var page = 2;
+
+      this.request.get('/api/v1/incidents', (error, response) => {
+        var pageOneResults = JSON.parse(response.body).incidents;
+        //pageOneResults is not getting passed in to callback on second ajax calll
+        this.request.get('/api/v1/incidents?page=' + page, (error, response, pageOneResults) => {
+          var pageTwoResults = JSON.parse(response.body).incidents;
+          console.log("page1", pageOneResults[0]);
+          console.log("page2", pageTwoResults[0]);
+          assert.notEqual(pageOneResults, pageTwoResults)
+          done();
+        });
       });
     });
 

--- a/test/incident-search-api-test.js
+++ b/test/incident-search-api-test.js
@@ -30,7 +30,7 @@ describe('Incident Search API', () => {
       var incNum = 'P16070041611'
       this.request.get('/api/v1/incidents?number=' + incNum, (error, response) => {
         if (error) { done(error); }
-        var parsedIncident = JSON.parse(response.body)[0]
+        var parsedIncident = JSON.parse(response.body).incidents[0]
         assert.equal(parsedIncident["incident number"], incNum);
         assert.equal(parsedIncident["neighborhood"], 'Pacific Beach');
         done();
@@ -41,7 +41,7 @@ describe('Incident Search API', () => {
       var priority = '3'
       this.request.get('/api/v1/incidents?priority=' + priority, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body);
+        var parsed = JSON.parse(response.body).incidents;
         var parsedIncident = parsed[0];
         assert.isAtLeast(parsed.length, 100);
         assert.equal(parsedIncident["priority"], priority);
@@ -54,8 +54,8 @@ describe('Incident Search API', () => {
       var beatNeighborhood = 'Pacific Beach';
       this.request.get('/api/v1/incidents?beat=' + beatNum, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body)
-        var parsedIncident = parsed[0]
+        var parsed = JSON.parse(response.body).incidents;
+        var parsedIncident = parsed[0];
         assert.isAtLeast(parsed.length, 100);
         assert.equal(parsedIncident["beat"], beatNum);
         assert.equal(parsedIncident["neighborhood"], beatNeighborhood);
@@ -68,7 +68,7 @@ describe('Incident Search API', () => {
       var beatNeighborhood = 'Pacific Beach';
       this.request.get('/api/v1/incidents?neighborhood=' + beatNeighborhood, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body)
+        var parsed = JSON.parse(response.body).incidents
         var parsedIncident = parsed[0]
         assert.isAtLeast(parsed.length, 100);
         assert.equal(parsedIncident["beat"], beatNum);
@@ -81,7 +81,7 @@ describe('Incident Search API', () => {
       var dispCode = 'K';
       this.request.get('/api/v1/incidents?disp_code=' + dispCode, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body);
+        var parsed = JSON.parse(response.body).incidents;
         var parsedIncident = parsed[0];
         assert.isAtLeast(parsed.length, 100);
         assert.equal(parsedIncident["disposition code"], dispCode);
@@ -94,7 +94,7 @@ describe('Incident Search API', () => {
       var dispCode = 'K';
       this.request.get('/api/v1/incidents?disp_desc=' + dispDescription, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body);
+        var parsed = JSON.parse(response.body).incidents;
         var parsedIncident = parsed[0];
         assert.isAtLeast(parsed.length, 100);
         assert.equal(parsedIncident["disposition code"], dispCode);
@@ -108,7 +108,7 @@ describe('Incident Search API', () => {
       var callCodeDescription = 'CHECK THE WELFARE';
       this.request.get('/api/v1/incidents?call_code=' + callCode, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body)
+        var parsed = JSON.parse(response.body).incidents
         var parsedIncident = parsed[0]
         assert.isAtLeast(parsed.length, 100);
         assert.equal(parsedIncident["call type code"], callCode);
@@ -122,7 +122,7 @@ describe('Incident Search API', () => {
       var callCodeDescription = 'CHECK THE WELFARE';
       this.request.get('/api/v1/incidents?call_desc=' + callCodeDescription, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body)
+        var parsed = JSON.parse(response.body).incidents
         var parsedIncident = parsed[0]
         assert.isAtLeast(parsed.length, 100);
         assert.equal(parsedIncident["call type code"], callCode);
@@ -135,7 +135,7 @@ describe('Incident Search API', () => {
       var street = 'EL CAJON';
       this.request.get('/api/v1/incidents?street=' + street, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body)
+        var parsed = JSON.parse(response.body).incidents
         var parsedIncident = parsed[0]
         assert.notEqual(parsedIncident["address"].indexOf(street), -1);
         done();
@@ -146,7 +146,7 @@ describe('Incident Search API', () => {
       var streetNum = '4100'
       this.request.get('/api/v1/incidents?street_number=' + streetNum, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body);
+        var parsed = JSON.parse(response.body).incidents;
         var parsedIncident = parsed[0];
         assert.notEqual(parsedIncident["address"].indexOf(streetNum), -1);
         done();
@@ -157,7 +157,7 @@ describe('Incident Search API', () => {
       var date = '2015-04-17';
       this.request.get('/api/v1/incidents?date=' + date, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body);
+        var parsed = JSON.parse(response.body).incidents;
         var firstParsedIncident = parsed[0];
         var lastParsedIncident = parsed[parsed.length - 1];
         assert.notEqual(firstParsedIncident["date"].indexOf(date), -1);
@@ -172,7 +172,7 @@ describe('Incident Search API', () => {
       var end = '2015-04-18'
       this.request.get('/api/v1/incidents?start_date=' + start + '&end_date=' + end, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body)
+        var parsed = JSON.parse(response.body).incidents
         var firstParsedIncident = parsed[0]
         var lastParsedIncident = parsed[parsed.length - 1]
         assert.equal(firstParsedIncident["date"].indexOf("2015-04-16"), -1);
@@ -188,7 +188,7 @@ describe('Incident Search API', () => {
       var callCode = 'CW';
       this.request.get('/api/v1/incidents?date=' + date + '&call_code=' + callCode, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body)
+        var parsed = JSON.parse(response.body).incidents
         var firstParsedIncident = parsed[0];
         var lastParsedIncident = parsed[parsed.length - 1];
         assert.notEqual(firstParsedIncident["date"].indexOf(date), -1);
@@ -204,7 +204,7 @@ describe('Incident Search API', () => {
       var searchCode = 'cW';
       this.request.get('/api/v1/incidents?neighborhood='+ searchNeigh+'&call_code=' + searchCode, (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body);
+        var parsed = JSON.parse(response.body).incidents;
         var firstParsedIncident = parsed[0];
         var lastParsedIncident = parsed[parsed.length - 1];
         assert.equal(firstParsedIncident["neighborhood"], "Pacific Beach");
@@ -219,7 +219,7 @@ describe('Incident Search API', () => {
       var badParam = 'bad';
       this.request.get('/api/v1/incidents?'+ badParam+'=not a param', (error, response) => {
         if (error) { done(error); }
-        var parsed = JSON.parse(response.body)
+        var parsed = JSON.parse(response.body);
         assert.deepEqual(parsed, {"invalid_request": "unrecognized search parameter"});
         done();
       });


### PR DESCRIPTION
- adds ordering on incidents by date ASC
- add pagination to incidents results through offset in query
- changes query method from findAll to findAndCountAll to get total number of incidents in result set to support pagination process for user.
  - change in query method also changes structure of results.  Keys for results customized from count and rows to total_incidents and incidents.  
  -   tests updated to fit this new structure
  -   api documentation updated for this structure and to add page as parameter
- adds testing for pagination - one skipped because I couldn't find a good way to test that page 1 results were different than page 2 results... but now realize it would be much easier to do this as a unit test... will do.

Questions:  I now have a handful of methods living in my incidents controller and I don't know how/if to get them out of here.  They don't really seem like methods that belong on the Model either.  Suggestions welcome. 

File: `controllers/incidents.js`  
Methods:
- `transformQuery` and `queryHashMap` - these take the params from the query string and transform them for the sequelize method to query the DB
- `customizeJsonKeys` and `serializeIncident`  - these take results of DB query and transform the keys of the outer and inner objects in the result set.

closes #11 
closes #34
